### PR TITLE
made timestep of solve for ic constant

### DIFF
--- a/quasi_geostrophic_model/qg_model.py
+++ b/quasi_geostrophic_model/qg_model.py
@@ -90,6 +90,9 @@ class base_class(object):
 
         # interpolate structured expression for q and solve for q
         self.q_old.interpolate(ufl_expression)
+
+        # edit constant time-step for initial condition solve and solve
+        self.const_dt.assign(1e-3)
         self.q_solver.solve()
 
         # update q_
@@ -357,9 +360,6 @@ class two_level_quasi_geostrophic(object):
             self.qg_class_f._base_class__update_forcing()
             self.qg_class_f.psi_forced.assign(self.qg_class_f.psi_forced / sqrt(self.qg_class_f.ml))
             inject(self.qg_class_f.psi_forced, self.qg_class_c.psi_forced)
-
-            # update coarse timestep to match finer one for just the one initial condition solve
-            self.qg_class_c.const_dt.assign(self.qg_class_f.const_dt)
 
             self.qg_class_c.initial_condition(ufl_expression_c, var)
             self.qg_class_f.initial_condition(ufl_expression_f, var)

--- a/quasi_geostrophic_model/qg_model.py
+++ b/quasi_geostrophic_model/qg_model.py
@@ -91,8 +91,7 @@ class base_class(object):
         # interpolate structured expression for q and solve for q
         self.q_old.interpolate(ufl_expression)
 
-        # edit constant time-step for initial condition solve and solve
-        self.const_dt.assign(1e-3)
+        # solve for q
         self.q_solver.solve()
 
         # update q_
@@ -234,6 +233,9 @@ class quasi_geostrophic(object):
         if var == 0:
             self.qg_class.q_.interpolate(ufl_expression)
         else:
+            # edit constant time-step for initial condition solve
+            self.qg_class.const_dt.assign(1e-3)
+
             # update forcing
             self.qg_class._base_class__update_forcing()
             self.qg_class.psi_forced.assign(self.qg_class.psi_forced / sqrt(self.qg_class.ml))
@@ -356,6 +358,10 @@ class two_level_quasi_geostrophic(object):
             self.qg_class_c.q_.interpolate(ufl_expression_c)
             self.qg_class_f.q_.interpolate(ufl_expression_f)
         else:
+            # edit constant time-step for initial condition solve
+            self.qg_class_c.const_dt.assign(1e-3)
+            self.qg_class_f.const_dt.assign(1e-3)
+
             # update forcing on fine and inject down to coarse
             self.qg_class_f._base_class__update_forcing()
             self.qg_class_f.psi_forced.assign(self.qg_class_f.psi_forced / sqrt(self.qg_class_f.ml))

--- a/tests/test_timestepper.py
+++ b/tests/test_timestepper.py
@@ -141,6 +141,46 @@ def test_zero_time():
     assert np.max(np.abs(QG.q_.dat.data - f.dat.data)) < 1e-5
 
 
+def test_timestep_ic_solve():
+
+    mesh = UnitSquareMesh(2, 2)
+    dg_fs = FunctionSpace(mesh, 'DG', 0)
+    cg_fs = FunctionSpace(mesh, 'CG', 1)
+
+    var = 0.0
+
+    x = SpatialCoordinate(mesh)
+    ufl_expression = sin(2 * pi * x[0])
+
+    QG = quasi_geostrophic(dg_fs, cg_fs, var)
+    QG.initial_condition(ufl_expression, 1.0)
+
+    assert QG.qg_class.const_dt.dat.data[0] == 1e-3
+
+
+def test_timestep_ic_solve_two():
+
+    mesh = UnitSquareMesh(2, 2)
+    mesh_hierarchy = MeshHierarchy(mesh, 1)
+    dg_fs_c = FunctionSpace(mesh_hierarchy[0], 'DG', 0)
+    cg_fs_c = FunctionSpace(mesh_hierarchy[0], 'CG', 1)
+    dg_fs_f = FunctionSpace(mesh_hierarchy[1], 'DG', 0)
+    cg_fs_f = FunctionSpace(mesh_hierarchy[1], 'CG', 1)
+
+    var = 0.0
+
+    x = SpatialCoordinate(mesh_hierarchy[0])
+    ufl_expression_c = sin(2 * pi * x[0])
+    x = SpatialCoordinate(mesh_hierarchy[1])
+    ufl_expression_f = sin(2 * pi * x[0])
+
+    QG = two_level_quasi_geostrophic(dg_fs_c, cg_fs_c, dg_fs_f, cg_fs_f, var)
+    QG.initial_condition(ufl_expression_c, ufl_expression_f, 1.0)
+
+    assert QG.qg_class_c.const_dt.dat.data[0] == 1e-3
+    assert QG.qg_class_f.const_dt.dat.data[0] == 1e-3
+
+
 if __name__ == "__main__":
     import os
     import pytest


### PR DESCRIPTION
Added a constant time-step change for the initial condition solve of `q`. Thus also removed the change in time-step of coarse initial condition solve to match finer one in `two_level_quasi_geostrophic`.