### PR TITLE
Changed from q to psi being time variable

### DIFF
--- a/quasi_geostrophic_model/qg_model.py
+++ b/quasi_geostrophic_model/qg_model.py
@@ -64,6 +64,7 @@ class base_class(object):
         # define functions
         self.q_ = Function(self.Vdg)  # actual q
         self.psi_ = Function(self.Vcg)  # actual streamfunction
+        self.psi_forced = Function(self.Vcg)  # forced streamfunction
         self.q_old = Function(self.Vdg)  # last time-step q
         self.dq = Function(self.Vdg)  # intermediate q for inter - RK steps
         self.forcing = Function(self.Vcg)
@@ -103,6 +104,10 @@ class base_class(object):
 
         # interpolate structured expression for q and solve for q
         self.q_.interpolate(ufl_expression)
+        self.q_old.assign(self.q_)
+
+        # update psi
+        self.psi_solver.solve()
 
     def setup_solver(self):
 
@@ -128,13 +133,13 @@ class base_class(object):
                                                                      'pc_type': 'sor'})
 
         self.n = FacetNormal(self.mesh)
-        self.un = 0.5 * (dot(self.gradperp(self.psi_), self.n) +
-                         abs(dot(self.gradperp(self.psi_), self.n)))
+        self.un = 0.5 * (dot(self.gradperp(self.psi_forced), self.n) +
+                         abs(dot(self.gradperp(self.psi_forced), self.n)))
 
         # setup advection solver
         self.a_mass = self.p * self.q * dx
 
-        self.a_int = (dot(grad(self.p), -self.gradperp(self.psi_) * self.q)) * dx
+        self.a_int = (dot(grad(self.p), -self.gradperp(self.psi_forced) * self.q)) * dx
 
         self.a_flux = (dot(jump(self.p), self.un('+') * self.q('+') -
                            self.un('-') * self.q('-'))) * dS
@@ -188,34 +193,35 @@ class base_class(object):
         """ adds the random field to psi at each RK step """
 
         if self.variance == 0:
-            self.psi_.assign(self.psi_)
+            self.psi_forced.assign(self.psi_)
         else:
-            self.psi_.assign(self.psi_ + self.forcing)
+            self.psi_forced.assign(self.psi_ + self.forcing)
 
     def timestep(self):
 
         """ completes one RK3 time-step """
 
-        # set old time-step to be current one
-        self.q_old.assign(self.q_)
-
         # 1st RK step
-        self.psi_solver.solve()
         self.__update_psi_forced()
         self.q_solver.solve()
         self.q_old.assign(self.dq)
+        self.psi_solver.solve()
 
         # 2nd RK step
-        self.psi_solver.solve()
         self.__update_psi_forced()
         self.q_solver.solve()
         self.q_old.assign(((3.0 / 4.0) * self.q_) + ((1.0 / 4.0) * self.dq))
+        self.psi_solver.solve()
 
         # 3rd RK step
-        self.psi_solver.solve()
         self.__update_psi_forced()
         self.q_solver.solve()
         self.q_.assign(((1.0 / 3.0) * self.q_) + ((2.0 / 3.0) * self.dq))
+        self.q_old.assign(self.q_)
+        self.psi_solver.solve()
+
+        # update the current time-step psi with forcing
+        self.__update_psi_forced()
 
 
 class quasi_geostrophic(object):
@@ -251,7 +257,7 @@ class quasi_geostrophic(object):
         self.dt = self.qg_class.dt
 
         self.q_ = self.qg_class.q_
-        self.psi_ = self.qg_class.psi_
+        self.psi_ = self.qg_class.psi_forced
 
         self.t = 0
 
@@ -382,7 +388,7 @@ class two_level_quasi_geostrophic(object):
                 raise ValueError('Time-steps are not the same without adaptivity')
 
         self.q_ = tuple([self.qg_class_c.q_, self.qg_class_f.q_])
-        self.psi_ = tuple([self.qg_class_c.psi_, self.qg_class_f.psi_])
+        self.psi_ = tuple([self.qg_class_c.psi_forced, self.qg_class_f.psi_forced])
 
         self.t = 0
 

--- a/quasi_geostrophic_model/qg_model.py
+++ b/quasi_geostrophic_model/qg_model.py
@@ -220,9 +220,6 @@ class base_class(object):
         self.q_old.assign(self.q_)
         self.psi_solver.solve()
 
-        # update the current time-step psi with forcing
-        self.__update_psi_forced()
-
 
 class quasi_geostrophic(object):
 
@@ -257,7 +254,7 @@ class quasi_geostrophic(object):
         self.dt = self.qg_class.dt
 
         self.q_ = self.qg_class.q_
-        self.psi_ = self.qg_class.psi_forced
+        self.psi_ = self.qg_class.psi_
 
         self.t = 0
 
@@ -388,7 +385,7 @@ class two_level_quasi_geostrophic(object):
                 raise ValueError('Time-steps are not the same without adaptivity')
 
         self.q_ = tuple([self.qg_class_c.q_, self.qg_class_f.q_])
-        self.psi_ = tuple([self.qg_class_c.psi_forced, self.qg_class_f.psi_forced])
+        self.psi_ = tuple([self.qg_class_c.psi_, self.qg_class_f.psi_])
 
         self.t = 0
 

--- a/tests/test_qg.py
+++ b/tests/test_qg.py
@@ -105,7 +105,7 @@ def test_zero_solution_q():
     QG.timestepper(1.0)
 
     assert np.all(QG.q_.dat.data[:] == 0.0)
-    assert np.any(QG.psi_.dat.data[:] != 0.0)
+    assert np.any(QG.psi_.dat.data[:] == 0.0)
 
 
 def test_zero_solution_q_2():
@@ -124,10 +124,10 @@ def test_zero_solution_q_2():
     QG.timestepper(1.0)
 
     assert np.all(QG.q_[0].dat.data[:] == 0.0)
-    assert np.any(QG.psi_[0].dat.data[:] != 0.0)
+    assert np.any(QG.psi_[0].dat.data[:] == 0.0)
 
     assert np.all(QG.q_[1].dat.data[:] == 0.0)
-    assert np.any(QG.psi_[1].dat.data[:] != 0.0)
+    assert np.any(QG.psi_[1].dat.data[:] == 0.0)
 
 
 def test_correct_fs():


### PR DESCRIPTION
Main features:

- Allowed, at each time step, `psi` and `q` to be used in the next timestep, and thus creating two time-variables instead of one, `q`.

Scheme goes:
`q_t, psi_t -> (advection) -> q_{t+1} -> (elliptic operator) -> q_{t+1}, psi_{t+1}`

- This means that we can ensemble transform each variable and be able to calculate statistics of them at each time-step, knowing they will be both be used in the next time-step.

- At the end of each time-step, the forcing used throughout all RK steps for `psi`, will be added to `psi` and put into a separate, output, variable `psi_forced`.

UPDATE:

- [x] Now, make sure that last point means the noise used for the NEW time-step (thus update noise at END of each time-step in the one-level and two-level classes, and thus in the initial condition, AFTER the interpolating and updating `psi`, will have to update the noise ready for first time-step.